### PR TITLE
Version bump with latest bugfixes, updates, and L2Ork Tweeter v.0.76.

### DIFF
--- a/io.github.pd_l2ork.Pd_L2Ork.yml
+++ b/io.github.pd_l2ork.Pd_L2Ork.yml
@@ -49,7 +49,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: 5076d837d422976d575742e012e320fa7ffa72a2
+    commit: 980e27bba09fba038641bb590e7c642c37a529be
   - type: patch
     path: patch/no-rsync-during-install.patch
 
@@ -145,7 +145,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: 5076d837d422976d575742e012e320fa7ffa72a2
+    commit: 980e27bba09fba038641bb590e7c642c37a529be
 
 - name: rpi-externals
   buildsystem: simple
@@ -163,7 +163,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: 5076d837d422976d575742e012e320fa7ffa72a2
+    commit: 980e27bba09fba038641bb590e7c642c37a529be
 
 - name: pd-abstractions
   buildsystem: simple
@@ -174,7 +174,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: 5076d837d422976d575742e012e320fa7ffa72a2
+    commit: 980e27bba09fba038641bb590e7c642c37a529be
 
 - name: pd-l2ork-integration
   buildsystem: simple
@@ -210,7 +210,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: 5076d837d422976d575742e012e320fa7ffa72a2
+    commit: 980e27bba09fba038641bb590e7c642c37a529be
   - type: file
     # x86_64 for now only. Still waiting for aarch64.
     url: https://dl.nwjs.io/v0.67.1/nwjs-sdk-v0.67.1-linux-x64.tar.gz

--- a/io.github.pd_l2ork.Pd_L2Ork.yml
+++ b/io.github.pd_l2ork.Pd_L2Ork.yml
@@ -49,7 +49,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 620e821e62c0a383df1ea747588b0409bd828c99
+    commit: 6ba149c7b8a14910e61816422b2d735483968375
   - type: patch
     path: patch/no-rsync-during-install.patch
 
@@ -145,7 +145,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 620e821e62c0a383df1ea747588b0409bd828c99
+    commit: 6ba149c7b8a14910e61816422b2d735483968375
 
 - name: rpi-externals
   buildsystem: simple
@@ -163,7 +163,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 620e821e62c0a383df1ea747588b0409bd828c99
+    commit: 6ba149c7b8a14910e61816422b2d735483968375
 
 - name: pd-abstractions
   buildsystem: simple
@@ -174,7 +174,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 620e821e62c0a383df1ea747588b0409bd828c99
+    commit: 6ba149c7b8a14910e61816422b2d735483968375
 
 - name: pd-l2ork-integration
   buildsystem: simple
@@ -210,7 +210,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 620e821e62c0a383df1ea747588b0409bd828c99
+    commit: 6ba149c7b8a14910e61816422b2d735483968375
   - type: file
     # x86_64 for now only. Still waiting for aarch64.
     url: https://dl.nwjs.io/v0.67.1/nwjs-sdk-v0.67.1-linux-x64.tar.gz

--- a/io.github.pd_l2ork.Pd_L2Ork.yml
+++ b/io.github.pd_l2ork.Pd_L2Ork.yml
@@ -48,8 +48,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231014'
-    commit: 9d1f6c93d943fd4f9d6fea4308431bd7fd444ae3
+    tag: '20231019'
+    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
   - type: patch
     path: patch/no-rsync-during-install.patch
 
@@ -144,8 +144,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231014'
-    commit: 9d1f6c93d943fd4f9d6fea4308431bd7fd444ae3
+    tag: '20231019'
+    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
 
 - name: rpi-externals
   buildsystem: simple
@@ -162,8 +162,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231014'
-    commit: 9d1f6c93d943fd4f9d6fea4308431bd7fd444ae3
+    tag: '20231019'
+    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
 
 - name: pd-abstractions
   buildsystem: simple
@@ -173,8 +173,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231014'
-    commit: 9d1f6c93d943fd4f9d6fea4308431bd7fd444ae3
+    tag: '20231019'
+    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
 
 - name: pd-l2ork-integration
   buildsystem: simple
@@ -209,8 +209,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231014'
-    commit: 9d1f6c93d943fd4f9d6fea4308431bd7fd444ae3
+    tag: '20231019'
+    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
   - type: file
     # x86_64 for now only. Still waiting for aarch64.
     url: https://dl.nwjs.io/v0.67.1/nwjs-sdk-v0.67.1-linux-x64.tar.gz

--- a/io.github.pd_l2ork.Pd_L2Ork.yml
+++ b/io.github.pd_l2ork.Pd_L2Ork.yml
@@ -49,7 +49,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
+    commit: 5076d837d422976d575742e012e320fa7ffa72a2
   - type: patch
     path: patch/no-rsync-during-install.patch
 
@@ -145,7 +145,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
+    commit: 5076d837d422976d575742e012e320fa7ffa72a2
 
 - name: rpi-externals
   buildsystem: simple
@@ -163,7 +163,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
+    commit: 5076d837d422976d575742e012e320fa7ffa72a2
 
 - name: pd-abstractions
   buildsystem: simple
@@ -174,7 +174,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
+    commit: 5076d837d422976d575742e012e320fa7ffa72a2
 
 - name: pd-l2ork-integration
   buildsystem: simple
@@ -210,7 +210,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231019'
-    commit: ae7ffe61484a1667efd1fa7b11429d23dcd72eb0
+    commit: 5076d837d422976d575742e012e320fa7ffa72a2
   - type: file
     # x86_64 for now only. Still waiting for aarch64.
     url: https://dl.nwjs.io/v0.67.1/nwjs-sdk-v0.67.1-linux-x64.tar.gz

--- a/io.github.pd_l2ork.Pd_L2Ork.yml
+++ b/io.github.pd_l2ork.Pd_L2Ork.yml
@@ -49,7 +49,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 6ba149c7b8a14910e61816422b2d735483968375
+    commit: 28adf0cee14e0663aca755bdbb6aa6a0a6ca326a
   - type: patch
     path: patch/no-rsync-during-install.patch
 
@@ -145,7 +145,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 6ba149c7b8a14910e61816422b2d735483968375
+    commit: 28adf0cee14e0663aca755bdbb6aa6a0a6ca326a
 
 - name: rpi-externals
   buildsystem: simple
@@ -163,7 +163,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 6ba149c7b8a14910e61816422b2d735483968375
+    commit: 28adf0cee14e0663aca755bdbb6aa6a0a6ca326a
 
 - name: pd-abstractions
   buildsystem: simple
@@ -174,7 +174,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 6ba149c7b8a14910e61816422b2d735483968375
+    commit: 28adf0cee14e0663aca755bdbb6aa6a0a6ca326a
 
 - name: pd-l2ork-integration
   buildsystem: simple
@@ -210,7 +210,7 @@ modules:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
     tag: '20231021'
-    commit: 6ba149c7b8a14910e61816422b2d735483968375
+    commit: 28adf0cee14e0663aca755bdbb6aa6a0a6ca326a
   - type: file
     # x86_64 for now only. Still waiting for aarch64.
     url: https://dl.nwjs.io/v0.67.1/nwjs-sdk-v0.67.1-linux-x64.tar.gz

--- a/io.github.pd_l2ork.Pd_L2Ork.yml
+++ b/io.github.pd_l2ork.Pd_L2Ork.yml
@@ -48,8 +48,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231019'
-    commit: 980e27bba09fba038641bb590e7c642c37a529be
+    tag: '20231021'
+    commit: 620e821e62c0a383df1ea747588b0409bd828c99
   - type: patch
     path: patch/no-rsync-during-install.patch
 
@@ -144,8 +144,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231019'
-    commit: 980e27bba09fba038641bb590e7c642c37a529be
+    tag: '20231021'
+    commit: 620e821e62c0a383df1ea747588b0409bd828c99
 
 - name: rpi-externals
   buildsystem: simple
@@ -162,8 +162,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231019'
-    commit: 980e27bba09fba038641bb590e7c642c37a529be
+    tag: '20231021'
+    commit: 620e821e62c0a383df1ea747588b0409bd828c99
 
 - name: pd-abstractions
   buildsystem: simple
@@ -173,8 +173,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231019'
-    commit: 980e27bba09fba038641bb590e7c642c37a529be
+    tag: '20231021'
+    commit: 620e821e62c0a383df1ea747588b0409bd828c99
 
 - name: pd-l2ork-integration
   buildsystem: simple
@@ -209,8 +209,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/pd-l2ork/pd-l2ork/
-    tag: '20231019'
-    commit: 980e27bba09fba038641bb590e7c642c37a529be
+    tag: '20231021'
+    commit: 620e821e62c0a383df1ea747588b0409bd828c99
   - type: file
     # x86_64 for now only. Still waiting for aarch64.
     url: https://dl.nwjs.io/v0.67.1/nwjs-sdk-v0.67.1-linux-x64.tar.gz


### PR DESCRIPTION
Version bump with latest bugfixes, updates, and L2Ork Tweeter v.0.76.